### PR TITLE
Fix duplicated nodes in the Node Tree and Use Callable.call_deferred

### DIFF
--- a/addons/label_font_auto_sizer/label_auto_sizer.gd
+++ b/addons/label_font_auto_sizer/label_auto_sizer.gd
@@ -1,7 +1,6 @@
 @tool
 @icon ("res://addons/label_font_auto_sizer/icon.svg")
 extends Label
-class_name LabelAutoSizer
 
 #region External variables
 ## The maximum size value in pixels that the font will grow to.

--- a/addons/label_font_auto_sizer/label_auto_sizer.gd
+++ b/addons/label_font_auto_sizer/label_auto_sizer.gd
@@ -11,7 +11,7 @@ extends Label
 		else:
 			_max_size = _min_size
 		if is_node_ready(): ## This setter gets called when the label enters the tree in the editor, even before it's ready. This if check prevents it.
-			_check_line_count.call_defered()
+			_check_line_count.call_deferred()
 ## The minimum size value in pixels that the font will shrink to.
 @export_range(1, 192, 1, "or_greater", "suffix:px") var _min_size: int = 1:
 	set(value):
@@ -20,12 +20,12 @@ extends Label
 		else:
 			_min_size = _max_size
 		if is_node_ready(): ## Same as _max_size comment.
-			_check_line_count.call_defered()
+			_check_line_count.call_deferred()
 @export var _lock_size_in_editor: bool =  false:
 	set(value):
 		_lock_size_in_editor = value
 		if value == false:
-			_check_line_count.call_defered()
+			_check_line_count.call_deferred()
 #endregion
 
 #region Internal variables
@@ -42,11 +42,11 @@ enum LABEL_SIZE_STATE {JUST_SHRUNK, IDLE, JUST_ENLARGED}
 ## Gets called in-editor and in-game. Sets some default values if necessary.
 func _ready() -> void:
 	if !_editor_defaults_set:
-		_set_editor_defaults.call_defered()
+		_set_editor_defaults.call_deferred()
 	if Engine.is_editor_hint():
-		_connect_signals.call_defered()
+		_connect_signals.call_deferred()
 	else:
-		_check_line_count.call_defered()
+		_check_line_count.call_deferred()
 	LabelFontAutoSizeManager.register_label(self)
 
 
@@ -64,13 +64,13 @@ func _on_font_resource_changed() -> void:
 func _on_label_rect_resized() -> void:
 	if !_editor_defaults_set:
 		return
-	_check_line_count.call_defered()
+	_check_line_count.call_deferred()
 
 
 ## Called by autosize manager whenever the locale_chaged() method is called, as the tr() object changes don't trigger
 ## the set_text() method of the label, thus the size and line_amount doesn't get checked.
 func _on_locale_changed() -> void:
-	_check_line_count.call_defered()
+	_check_line_count.call_deferred()
 
 
 ## Gets called on scene changes and when the label is freed and erases itself from the autosize manager.
@@ -99,7 +99,7 @@ func _set(property: StringName, value: Variant) -> bool:
 	match property:
 		"text":
 			text = value
-			_check_line_count.call_defered()
+			_check_line_count.call_deferred()
 			return true
 		"label_settings":
 			if _label_settings_just_duplicated: ## Need to check because this gets called whenever we duplicate the resource as well.
@@ -208,6 +208,6 @@ func _set_editor_defaults() -> void:
 ##In a real scenario you wouldn't be changing the text from within the class itself though.**
 func set_text(new_text: String) -> void:
 	text = new_text
-	_check_line_count.call_defered()
+	_check_line_count.call_deferred()
 #endregion
 

--- a/addons/label_font_auto_sizer/label_auto_sizer.gd
+++ b/addons/label_font_auto_sizer/label_auto_sizer.gd
@@ -11,7 +11,7 @@ extends Label
 		else:
 			_max_size = _min_size
 		if is_node_ready(): ## This setter gets called when the label enters the tree in the editor, even before it's ready. This if check prevents it.
-			call_deferred(_check_line_count.get_method())
+			_check_line_count.call_defered()
 ## The minimum size value in pixels that the font will shrink to.
 @export_range(1, 192, 1, "or_greater", "suffix:px") var _min_size: int = 1:
 	set(value):
@@ -20,12 +20,12 @@ extends Label
 		else:
 			_min_size = _max_size
 		if is_node_ready(): ## Same as _max_size comment.
-			call_deferred(_check_line_count.get_method())
+			_check_line_count.call_defered()
 @export var _lock_size_in_editor: bool =  false:
 	set(value):
 		_lock_size_in_editor = value
 		if value == false:
-			call_deferred(_check_line_count.get_method())
+			_check_line_count.call_defered()
 #endregion
 
 #region Internal variables
@@ -42,11 +42,11 @@ enum LABEL_SIZE_STATE {JUST_SHRUNK, IDLE, JUST_ENLARGED}
 ## Gets called in-editor and in-game. Sets some default values if necessary.
 func _ready() -> void:
 	if !_editor_defaults_set:
-		call_deferred(_set_editor_defaults.get_method())
+		_set_editor_defaults.call_defered()
 	if Engine.is_editor_hint():
-		call_deferred(_connect_signals.get_method())
+		_connect_signals.call_defered()
 	else:
-		call_deferred(_check_line_count.get_method())
+		_check_line_count.call_defered()
 	LabelFontAutoSizeManager.register_label(self)
 
 
@@ -64,13 +64,13 @@ func _on_font_resource_changed() -> void:
 func _on_label_rect_resized() -> void:
 	if !_editor_defaults_set:
 		return
-	call_deferred(_check_line_count.get_method())
+	_check_line_count.call_defered()
 
 
 ## Called by autosize manager whenever the locale_chaged() method is called, as the tr() object changes don't trigger
 ## the set_text() method of the label, thus the size and line_amount doesn't get checked.
 func _on_locale_changed() -> void:
-	call_deferred(_check_line_count.get_method())
+	_check_line_count.call_defered()
 
 
 ## Gets called on scene changes and when the label is freed and erases itself from the autosize manager.
@@ -99,7 +99,7 @@ func _set(property: StringName, value: Variant) -> bool:
 	match property:
 		"text":
 			text = value
-			call_deferred(_check_line_count.get_method())
+			_check_line_count.call_defered()
 			return true
 		"label_settings":
 			if _label_settings_just_duplicated: ## Need to check because this gets called whenever we duplicate the resource as well.
@@ -208,6 +208,6 @@ func _set_editor_defaults() -> void:
 ##In a real scenario you wouldn't be changing the text from within the class itself though.**
 func set_text(new_text: String) -> void:
 	text = new_text
-	call_deferred(_check_line_count.get_method())
+	_check_line_count.call_defered()
 #endregion
 

--- a/addons/label_font_auto_sizer/rich_label_auto_sizer.gd
+++ b/addons/label_font_auto_sizer/rich_label_auto_sizer.gd
@@ -11,7 +11,7 @@ extends RichTextLabel
 		else:
 			_max_size = _min_size
 		if is_node_ready(): ## This setter gets called when the label enters the tree in the editor, even before it's ready. This if check prevents it.
-			call_deferred(_check_line_count.get_method())
+			_check_line_count.call_defered()
 ## The minimum size value in pixels that the font will shrink to.
 @export_range(1, 192, 1, "or_greater", "suffix:px") var _min_size: int = 1:
 	set(value):
@@ -20,12 +20,12 @@ extends RichTextLabel
 		else:
 			_min_size = _max_size
 		if is_node_ready(): ## Same as _max_size comment.
-			call_deferred(_check_line_count.get_method())
+			_check_line_count.call_defered()
 @export var _lock_size_in_editor: bool =  false:
 	set(value):
 		_lock_size_in_editor = value
 		if value == false:
-			call_deferred(_check_line_count.get_method())
+			_check_line_count.call_defered()
 #endregion
 
 #region Internal variables
@@ -42,11 +42,11 @@ enum LABEL_SIZE_STATE {JUST_SHRUNK, IDLE, JUST_ENLARGED}
 ## Gets called in-editor and in-game. Sets some default values if necessary.
 func _ready() -> void:
 	if !_editor_defaults_set:
-		call_deferred(_set_editor_defaults.get_method())
+		_set_editor_defaults.call_defered()
 	if Engine.is_editor_hint():
-		call_deferred(_connect_signals.get_method())
+		_connect_signals.call_defered()
 	else:
-		call_deferred(_check_line_count.get_method())
+		_check_line_count.call_defered()
 	LabelFontAutoSizeManager.register_label(self)
 
 
@@ -63,13 +63,13 @@ func _on_font_resource_changed() -> void:
 func _on_label_rect_resized() -> void:
 	if !_editor_defaults_set:
 		return
-	call_deferred(_check_line_count.get_method())
+	_check_line_count.call_defered()
 
 
 ## Called by autosize manager whenever the locale_chaged() method is called, as the tr() object changes don't trigger
 ## the set_text() method of the label, thus the size and line_amount doesn't get checked.
 func _on_locale_changed() -> void:
-	call_deferred(_check_line_count.get_method())
+	_check_line_count.call_defered()
 
 
 ## Gets called on scene changes and when the label is freed and erases itself from the autosize manager.
@@ -94,7 +94,7 @@ func _set(property: StringName, value: Variant) -> bool:
 	match property:
 		"text":
 			text = value
-			call_deferred(_check_line_count.get_method())
+			_check_line_count.call_defered()
 			return true
 		_:
 			return false
@@ -140,7 +140,7 @@ func _shrink_font():
 		_last_size_state = LABEL_SIZE_STATE.IDLE
 	else:
 		_last_size_state = LABEL_SIZE_STATE.JUST_SHRUNK
-		call_deferred(_check_line_count.get_method())
+		_check_line_count.call_defered()
 
 
 ## Makes the font size larger. Rechecks/Shrinks/stops the cycle depending on the conditions.
@@ -154,7 +154,7 @@ func _enlarge_font():
 			_last_size_state = LABEL_SIZE_STATE.IDLE
 	else:
 		_last_size_state = LABEL_SIZE_STATE.JUST_ENLARGED
-		call_deferred(_check_line_count.get_method())
+		_check_line_count.call_defered()
 
 
 ## Applies the new font size.
@@ -183,6 +183,6 @@ func _set_editor_defaults() -> void:
 ##In a real scenario you wouldn't be changing the text from within the class itself though.**
 func set_text(new_text: String) -> void:
 	text = new_text
-	call_deferred(_check_line_count.get_method())
+	_check_line_count.call_defered()
 #endregion
 

--- a/addons/label_font_auto_sizer/rich_label_auto_sizer.gd
+++ b/addons/label_font_auto_sizer/rich_label_auto_sizer.gd
@@ -11,7 +11,7 @@ extends RichTextLabel
 		else:
 			_max_size = _min_size
 		if is_node_ready(): ## This setter gets called when the label enters the tree in the editor, even before it's ready. This if check prevents it.
-			_check_line_count.call_defered()
+			_check_line_count.call_deferred()
 ## The minimum size value in pixels that the font will shrink to.
 @export_range(1, 192, 1, "or_greater", "suffix:px") var _min_size: int = 1:
 	set(value):
@@ -20,12 +20,12 @@ extends RichTextLabel
 		else:
 			_min_size = _max_size
 		if is_node_ready(): ## Same as _max_size comment.
-			_check_line_count.call_defered()
+			_check_line_count.call_deferred()
 @export var _lock_size_in_editor: bool =  false:
 	set(value):
 		_lock_size_in_editor = value
 		if value == false:
-			_check_line_count.call_defered()
+			_check_line_count.call_deferred()
 #endregion
 
 #region Internal variables
@@ -42,11 +42,11 @@ enum LABEL_SIZE_STATE {JUST_SHRUNK, IDLE, JUST_ENLARGED}
 ## Gets called in-editor and in-game. Sets some default values if necessary.
 func _ready() -> void:
 	if !_editor_defaults_set:
-		_set_editor_defaults.call_defered()
+		_set_editor_defaults.call_deferred()
 	if Engine.is_editor_hint():
-		_connect_signals.call_defered()
+		_connect_signals.call_deferred()
 	else:
-		_check_line_count.call_defered()
+		_check_line_count.call_deferred()
 	LabelFontAutoSizeManager.register_label(self)
 
 
@@ -63,13 +63,13 @@ func _on_font_resource_changed() -> void:
 func _on_label_rect_resized() -> void:
 	if !_editor_defaults_set:
 		return
-	_check_line_count.call_defered()
+	_check_line_count.call_deferred()
 
 
 ## Called by autosize manager whenever the locale_chaged() method is called, as the tr() object changes don't trigger
 ## the set_text() method of the label, thus the size and line_amount doesn't get checked.
 func _on_locale_changed() -> void:
-	_check_line_count.call_defered()
+	_check_line_count.call_deferred()
 
 
 ## Gets called on scene changes and when the label is freed and erases itself from the autosize manager.
@@ -94,7 +94,7 @@ func _set(property: StringName, value: Variant) -> bool:
 	match property:
 		"text":
 			text = value
-			_check_line_count.call_defered()
+			_check_line_count.call_deferred()
 			return true
 		_:
 			return false
@@ -140,7 +140,7 @@ func _shrink_font():
 		_last_size_state = LABEL_SIZE_STATE.IDLE
 	else:
 		_last_size_state = LABEL_SIZE_STATE.JUST_SHRUNK
-		_check_line_count.call_defered()
+		_check_line_count.call_deferred()
 
 
 ## Makes the font size larger. Rechecks/Shrinks/stops the cycle depending on the conditions.
@@ -154,7 +154,7 @@ func _enlarge_font():
 			_last_size_state = LABEL_SIZE_STATE.IDLE
 	else:
 		_last_size_state = LABEL_SIZE_STATE.JUST_ENLARGED
-		_check_line_count.call_defered()
+		_check_line_count.call_deferred()
 
 
 ## Applies the new font size.
@@ -183,6 +183,6 @@ func _set_editor_defaults() -> void:
 ##In a real scenario you wouldn't be changing the text from within the class itself though.**
 func set_text(new_text: String) -> void:
 	text = new_text
-	_check_line_count.call_defered()
+	_check_line_count.call_deferred()
 #endregion
 

--- a/addons/label_font_auto_sizer/rich_label_auto_sizer.gd
+++ b/addons/label_font_auto_sizer/rich_label_auto_sizer.gd
@@ -1,7 +1,6 @@
 @tool
 @icon ("res://addons/label_font_auto_sizer/icon.svg")
 extends RichTextLabel
-class_name RichLabelAutoSizer
 
 #region External variables
 ## The maximum size value in pixels that the font will grow to.


### PR DESCRIPTION
removed `class_name ...` in `rich_label_auto_sizer.gd` and `label_auto_sizer.gd` causing a duplication in the Node Tree.